### PR TITLE
Do not use pnpm cache for releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,7 +165,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         uses: nick-fields/retry@v3.0.0


### PR DESCRIPTION
Ref: https://github.com/platformatic/platformatic/pull/4784

Removes pnpm dependency caching from the release publishing workflow to avoid reusing a potentially poisoned cache when publishing packages.